### PR TITLE
Add vertical margins based on screen size

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,14 +25,14 @@
         </nav>
       </div>
     </header>
-    <section class="container">
+    <section class="container storyline">
       <div class="row">
-        <p class="story-divider col-sm-12">
+        <p class="story-divider">
           Hi, I'm John Quinn...
         </p>
       </div>
       <div class="row">
-        <p class="story-scene col-sm-12">
+        <p class="story-scene">
           I build products<br>
           to create a<br>
           <span class="underline">sustainable future.</span>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -29,18 +29,41 @@ header p {
   margin: 0;
 }
 
+
+/* Match section content to height of viewport */
+
+
+@media (min-height: 750px) {
+  .storyline {
+    margin: 100px inherit;
+  }
+}
+/*
+@media (max-height: 900px) {
+  .storyline {
+    margin: 700px 0;
+  }
+}
+
+@media (max-height: 1200px) {
+  .storyline  {
+    margin: 1000px 0;
+  }
+} */
+
+/* Format sections of the storyline */
 .storyline {
   display: flex;
 }
 
-.story-scene {
+.story-divider {
+  margin-top: 5%;
   margin-bottom: 20px;
   justify-content: left;
   font-size: 36px;
 }
 
-.story-divider {
-  margin-top: 5%;
+.story-scene {
   margin-bottom: 20px;
   justify-content: left;
   font-size: 36px;


### PR DESCRIPTION
@hdavidzhu everything I have read for the past couple days indicates that this code should work. 

```
@media (min-height: 750px) {
    .storyline {
        margin: 100px inherit;
    }
}
```

When the viewport is at least 750px tall, then 100px of vertical margin should be added to the container. For some reason, the rows get collapsed. There must be some part of flexbox, bootstrap grids, or margins that I do not understand, but I have read all the documentation on MDN and Bootstrap about the topics and looked through StackOverflow. I cannot figure it out. What do developers usually do in these situations? 

I have tried twenty variations of the code to see if I could understand what happens. I tried moving which element the margin was added to. I tried using padding instead of margin. I tried different margin types. I tried adding and removing flexbox. Nothing seems to work, but my bugs are relatively consistent. They all collapse the two bootstrap rows to a single line and usually do not update the margins at the viewport dimensions I would expect.

I am going to try a couple other HTML layouts, then call it quits. But I imagine developers run into these types of issues all the time. How do you diagnose them?