### PR TITLE
Add vertical margins to show only the first part of the story on the page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,14 +25,12 @@
         </nav>
       </div>
     </header>
-    <section class="container storyline">
-      <div class="row">
-        <p class="story-divider">
+    <section class="container">
+      <div class="row storyline">
+        <p class="story-divider col-12">
           Hi, I'm John Quinn...
         </p>
-      </div>
-      <div class="row">
-        <p class="story-scene">
+        <p class="story-scene col-12">
           I build products<br>
           to create a<br>
           <span class="underline">sustainable future.</span>

--- a/index.html
+++ b/index.html
@@ -25,14 +25,14 @@
         </nav>
       </div>
     </header>
-    <section class="container">
+    <section class="container storyline">
       <div class="row">
-        <p class="story-divider col-sm-12">
+        <p class="story-divider">
           Hi, I'm John Quinn...
         </p>
       </div>
       <div class="row">
-        <p class="story-scene col-sm-12">
+        <p class="story-scene">
           I build products<br>
           to create a<br>
           <span class="underline">sustainable future.</span>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -33,23 +33,22 @@ header p {
 /* Match section content to height of viewport */
 
 
-@media (min-height: 750px) {
+@media (min-height: 500px) {
   .storyline {
-    margin: 100px inherit;
-  }
+    margin: 100px auto;
 }
-/*
-@media (max-height: 900px) {
+
+@media (min-height: 700px) {
   .storyline {
-    margin: 700px 0;
+    margin: 200px 0;
   }
 }
 
-@media (max-height: 1200px) {
+@media (min-height: 900px) {
   .storyline  {
-    margin: 1000px 0;
+    margin: 300px 0;
   }
-} */
+}
 
 /* Format sections of the storyline */
 .storyline {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -29,18 +29,41 @@ header p {
   margin: 0;
 }
 
+
+/* Match section content to height of viewport */
+
+
+@media (min-height: 750px) {
+  .storyline {
+    margin: 100px inherit;
+  }
+}
+/*
+@media (max-height: 900px) {
+  .storyline {
+    margin: 700px 0;
+  }
+}
+
+@media (max-height: 1200px) {
+  .storyline  {
+    margin: 1000px 0;
+  }
+} */
+
+/* Format sections of the storyline */
 .storyline {
   display: flex;
 }
 
-.story-scene {
+.story-divider {
+  margin-top: 5%;
   margin-bottom: 20px;
   justify-content: left;
   font-size: 36px;
 }
 
-.story-divider {
-  margin-top: 5%;
+.story-scene {
   margin-bottom: 20px;
   justify-content: left;
   font-size: 36px;


### PR DESCRIPTION
<img width="1440" alt="screen shot 2018-06-23 at 8 55 53 am" src="https://user-images.githubusercontent.com/8930410/41809921-56f23f9e-76c3-11e8-9394-58dd867a0405.png">

I got the vertical margins to work by re-structuring my html. But, I am still not sure why the other method did not work, which I would like to figure out so that I avoid bugs in the future. 

This solution is not very elegant either. The first part of the story should be vertically centered on the page, which means the margins would have to update dynamically. I might just say that it is good enough for now though. It's probably not necessary for perfect alignment. I only wanted to separate sections of the story to make it more readable and easier to absorb. I have achieved that here, even if it looks a little unprofessional. 